### PR TITLE
update Autohooker.php to fix broken function

### DIFF
--- a/library/bbSubscriptions/Autohooker.php
+++ b/library/bbSubscriptions/Autohooker.php
@@ -102,7 +102,7 @@ abstract class bbSubscriptions_Autohooker {
 			return true;
 		}
 
-		$method = new ReflectionMethod('Sputnik_Library_Plugin_Base', 'check_eaccelerator_saneness');
+		$method = new ReflectionMethod('bbSubscriptions_Autohooker', 'check_eaccelerator_saneness');
 		$comment = $method->getDocComment();
 
 		return (strpos($comment, "If you can find me, it's sane.") !== false);


### PR DESCRIPTION
The check_eaccelerator_saneness was incorrectly looking for Sputnik_Library_Plugin_Base. It seems like Sputnik_Library_Plugin_Base was renamed to bbSubscriptions_Autohooker but the check_eaccelerator_saneness function was not updated. This problem only shows up for people who have eAccelerator installed.
