### PR TITLE
Update bbPress.php

### DIFF
--- a/library/Falcon/Connector/bbPress.php
+++ b/library/Falcon/Connector/bbPress.php
@@ -127,7 +127,12 @@ class Falcon_Connector_bbPress {
 			'id'     => $topic_id,
 			'author' => $reply_author_name,
 		);
-		$this->handler->send_mail( $user_ids, $subject, $text, $options );
+		$message = new Falcon_Message();
+		$message->set_subject( $subject );
+		$message->set_text( $text);
+		$message->set_options( $options );
+		$this->handler->send_mail( $user_ids, $message);
+
 
 		do_action( 'bbp_post_notify_subscribers', $reply_id, $topic_id, $user_ids );
 


### PR DESCRIPTION
fix error message: Catchable fatal error: Argument 2 passed to Falcon_Handler_Postmark::send_mail() must be an instance of Falcon_Message, string given, called in wp-content/plugins/Falcon-master/library/Falcon/Connector/bbPress.php on line 130 and defined in wp-content/plugins/Falcon-master/library/Falcon/Handler/Postmark.php on line 33
