### PR TITLE
Correctly encode `from` and `to` names for wp_mail

### DIFF
--- a/library/Falcon/Handler/WPMail.php
+++ b/library/Falcon/Handler/WPMail.php
@@ -25,7 +25,7 @@ class Falcon_Handler_WPMail implements Falcon_Handler {
 		foreach ( $users as $user ) {
 
 			$headers = array(
-				'From'         => sprintf( '%s <%s>', $author, $from ),
+				'From'         => sprintf( '"%s" <%s>', mb_encode_mimeheader( $author ), $from ),
 				'Reply-To'     => sprintf( '%s', $message->get_reply_address( $user ) ),
 				'Content-Type' => 'text/html',
 			);
@@ -57,7 +57,7 @@ class Falcon_Handler_WPMail implements Falcon_Handler {
 			}
 
 			$result = wp_mail(
-				sprintf( '%s <%s>', $user->display_name, $user->user_email ),
+				sprintf( '"%s" <%s>', mb_encode_mimeheader( $user->display_name ), $user->user_email ),
 				$message->get_subject(),
 				$message->get_html(),
 				array_values( $headers )


### PR DESCRIPTION
AFAIK a same fix was required for SES - https://github.com/humanmade/aws-ses-wp-mail/issues/46
I wonder if same fix will also be required for mandrill #60

In my case, The `Go To Action` schema in Gmail was not working until this change was made.

![image](https://user-images.githubusercontent.com/2931091/133372435-048e8234-0c5c-4f15-b3f1-f1e5635eb99c.png)
