### PR TITLE
Declare api_key properties to avoid deprecation error

### DIFF
--- a/library/Falcon/Handler/Mandrill.php
+++ b/library/Falcon/Handler/Mandrill.php
@@ -22,6 +22,13 @@ class Falcon_Handler_Mandrill implements Falcon_Handler {
 	 */
 	protected static $current_options = array();
 
+	/**
+	 * Mandrill API key.
+	 *
+	 * @var string
+	 */
+	protected $api_key;
+
 	public function __construct($options) {
 		if (empty($options) || empty($options['api_key'])) {
 			throw new Exception(__('Mandrill API key not set', 'falcon'));

--- a/library/Falcon/Handler/Postmark.php
+++ b/library/Falcon/Handler/Postmark.php
@@ -23,6 +23,13 @@ class Falcon_Handler_Postmark implements Falcon_Handler {
 	 */
 	protected static $current_options = array();
 
+	/**
+	 * Postmark API key.
+	 *
+	 * @var string
+	 */
+	protected $api_key;
+
 	public function __construct($options) {
 		if (empty($options) || empty($options['api_key'])) {
 			throw new Exception(__('Postmark API key not set', 'falcon'));


### PR DESCRIPTION
After updating a site using Falcon to PHP 8.3, we're seeing a variety of deprecation warnings:

```
E_DEPRECATEDCreation of dynamic property Falcon_Handler_Mandrill::$api_key is deprecated
/usr/src/app/content/plugins/falcon-notifications/library/Falcon/Handler/Mandrill.php:29
E_DEPRECATEDCreation of dynamic property Falcon_Handler_Mandrill::$api_key is deprecated
/usr/src/app/content/plugins/falcon-notifications/library/Falcon/Handler/Mandrill.php:29
```

I assume this will be a string, but for maximum flexibility this PR currently only declares the property, not its type.