### PR TITLE
Fix: save_profile_settings drops every site after the first on PHP 8

### DIFF
--- a/library/Falcon/Connector.php
+++ b/library/Falcon/Connector.php
@@ -168,9 +168,13 @@ abstract class Falcon_Connector {
 				}
 				$value = $args[ $request_key ];
 
-				// Check the value is valid
-				$options = array_keys( $options );
-				if ( ! in_array( $value, $options ) ) {
+				// Check the value is valid.
+				// Use a fresh local so we don't mutate the outer foreach's $options —
+				// on subsequent sites that would leave $options as a numeric-indexed
+				// list, and on PHP 8+ in_array() with non-numeric strings against ints
+				// no longer loose-equates, so all sites after the first silently skip.
+				$valid_values = array_keys( $options );
+				if ( ! in_array( $value, $valid_values, true ) ) {
 					continue;
 				}
 


### PR DESCRIPTION
## Summary

`Falcon_Connector::save_profile_settings()` shadow-mutated the outer foreach's `$options` to a numeric-indexed array. On the second and subsequent sites in the network profile-page save, the validity check became `in_array($value, [0, 1])`.

On PHP 7 the string→int loose cast made `'all' == 0` evaluate to `true`, so the check still passed by accident. PHP 8 reversed string-to-number comparison: the int is now cast to string instead, so `'all' != 0` and the check fails — every site after the first silently `continue`s past the save.

Result: on a multisite network profile page, only the first row in the table actually persists. Every other site's change is dropped without any error.

## Fix

Use a fresh local (`$valid_values`) instead of mutating `$options`, and switch to strict `in_array(..., true)`.

## Test plan

- [x] On PHP 8.3, save changes for two sites in one POST — both persist.
- [ ] Verify on PHP 7.4 (if still supported) — still passes; the strict comparison only tightens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)